### PR TITLE
Fix region calculation for food limit in MeatPie

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/MeatPie.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/MeatPie.java
@@ -53,9 +53,9 @@ public class MeatPie extends Food {
 		if (Dungeon.isChallenged(Challenges.EXSG)) {
 			Buff.prolong(hero, Haste.class, 8f);
 
-			int region = Statistics.deepestFloor / 5;
+			int region = Math.min(Statistics.deepestFloor / 5, foodLimit.length - 1);
 			// Can we get more STR from food?
-			if (Statistics.GetFoodLing < foodLimit[foodLimit.length - 1]) {
+			if (Statistics.GetFoodLing < foodLimit[region]) {
 				// Random chance
 				if (Random.Float() > 0.25f + hero.STR / 50f) {
 					Statistics.GetFoodLing++;


### PR DESCRIPTION
My old PR had a bug where it always compared `Statistics.GetFoodLing` to 1. 

Before
```
int region = Statistics.deepestFloor / 5;
if (Statistics.GetFoodLing < foodLimit[foodLimit.length - 1]) { // ALWAYS 1
...
```
After
```
int region = Math.min(Statistics.deepestFloor / 5, foodLimit.length - 1);
if (Statistics.GetFoodLing < foodLimit[region]) { // Follows old pattern
...
```
Note that **this repository does not accept pull requests!** The code here is provided in hopes that others may find it useful for their own projects, not to allow community contribution. Issue reports of all kinds (bug reports, feature requests, etc.) are welcome.